### PR TITLE
Add "wikipedia" and "description" properties.

### DIFF
--- a/Oddity/API/Models/Capsule/CapsuleInfo.cs
+++ b/Oddity/API/Models/Capsule/CapsuleInfo.cs
@@ -49,5 +49,11 @@ namespace Oddity.API.Models.Capsule
         public SizeInfo HeightWithTrunk { get; set; }
 
         public SizeInfo Diameter { get; set; }
+
+        [JsonProperty("wikipedia")]
+        public string Wikipedia { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
     }
 }


### PR DESCRIPTION
Two properties were missing that are present in the JSON data but not in the Capsule Model.