### PR TITLE
Tentative Launch Dates

### DIFF
--- a/Oddity/API/Models/Launch/LaunchInfo.cs
+++ b/Oddity/API/Models/Launch/LaunchInfo.cs
@@ -26,6 +26,12 @@ namespace Oddity.API.Models.Launch
         [JsonProperty("launch_date_local")]
         public DateTime? LaunchDateLocal { get; set; }
 
+        [JsonProperty("is_tentative")]
+        public bool IsTentative { get; set; }
+
+        [JsonProperty("tentative_max_precision")]
+        public TentativeMaxPrecision? TentativeMaxPrecision { get; set; }
+
         public RocketInfo Rocket { get; set; }
         public ReuseInfo Reuse { get; set; }
         public TelemetryInfo Telemetry { get; set; }

--- a/Oddity/API/Models/Launch/TentativeMaxPrecision.cs
+++ b/Oddity/API/Models/Launch/TentativeMaxPrecision.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.Serialization;
+
+namespace Oddity.API.Models.Launch
+{
+    public enum TentativeMaxPrecision
+    {
+        [EnumMember(Value = "hour")]
+        Hour,
+
+        [EnumMember(Value = "day")]
+        Day,
+
+        [EnumMember(Value = "month")]
+        Month,
+
+        [EnumMember(Value = "quarter")]
+        Quarter,
+
+        [EnumMember(Value = "half")]
+        Half,
+
+        [EnumMember(Value = "year")]
+        Year
+    }
+}


### PR DESCRIPTION
 - Added TentativeMaxPrecision enum to represent how precise the launch date is.
 - Added `IsTentative` and `TentativeMaxPrecision` fields to `LaunchInfo`

You can see an example of a flight which uses this feature [here](https://api.spacexdata.com/v2/launches/all?flight_number=80).

[This changelog](https://github.com/r-spacex/SpaceX-API/blob/39a2f01c5f4ab67395877e3c3e4adb204a6b431c/CHANGELOG.md) indicates that the valid values in this field _for the v3 API_ are the ones I have added into the enum. Obviously I am assuming the same values are valid for v2!