### PR TITLE
Added support for very low earth orbit (required by starlink)

### DIFF
--- a/Oddity/API/Models/Launch/Rocket/SecondStage/Orbit/OrbitRegime.cs
+++ b/Oddity/API/Models/Launch/Rocket/SecondStage/Orbit/OrbitRegime.cs
@@ -4,6 +4,9 @@ namespace Oddity.API.Models.Launch.Rocket.SecondStage.Orbit
 {
     public enum OrbitRegime
     {
+        [EnumMember(Value = "very-low-earth")]
+        VeryLowEarth,
+
         [EnumMember(Value = "low-earth")]
         LowEarth,
 

--- a/Oddity/API/Models/Launch/Rocket/SecondStage/Orbit/OrbitType.cs
+++ b/Oddity/API/Models/Launch/Rocket/SecondStage/Orbit/OrbitType.cs
@@ -4,6 +4,9 @@ namespace Oddity.API.Models.Launch.Rocket.SecondStage.Orbit
 {
     public enum OrbitType
     {
+        [EnumMember(Value = "VLEO")]
+        VLEO,
+
         [EnumMember(Value = "PO")]
         PO,
 


### PR DESCRIPTION
The next spacex launch ([StarLink](https://api.spacexdata.com/v2/launches/next)) is failing to parse correctly because very low earth orbit is missing.