### PR TITLE
bumped version to dotnet 5/netstandard 2.1

### DIFF
--- a/Examples/OverviewApp/OverviewApp.csproj
+++ b/Examples/OverviewApp/OverviewApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Examples/UpcomingLaunchesApp/UpcomingLaunchesApp.csproj
+++ b/Examples/UpcomingLaunchesApp/UpcomingLaunchesApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Oddity/Oddity.csproj
+++ b/Oddity/Oddity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>Tearth</Authors>
     <PackageLicenseUrl>https://github.com/Tearth/Oddity/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/Tearth/Oddity</RepositoryUrl>


### PR DESCRIPTION
Bumping versions from netstandard 1.1 => netstandard 2.1 & dotnet 3.0=> .net5.
Tested with both UpcomingLaunches & Overview