### PR TITLE
Fixed querying cores by serial number

### DIFF
--- a/Examples/UpcomingLaunchesApp/Program.cs
+++ b/Examples/UpcomingLaunchesApp/Program.cs
@@ -39,6 +39,20 @@ namespace UpcomingLaunchesApp
             Console.WriteLine("Rocket           | " + nextLaunchData.Rocket.Value.Name);
             Console.WriteLine("Payloads         | " + string.Join(", ", nextLaunchData.Payloads.Select(p => GetPayloadInfo(p.Value))));
             Console.WriteLine();
+
+            var cores = await oddity.CoresEndpoint.Query().WithFieldEqual(a => a.Serial, nextLaunchData.Cores.First().Core.Value.Serial).ExecuteAsync();
+            if (cores.Data.Count != 1)
+                Console.WriteLine("Failed to find core!");
+            else
+            {
+                var core = cores.Data[0];
+                Console.WriteLine("Core:");
+                Console.WriteLine("---------------------------------------------------------------------------");
+                Console.WriteLine("Serial           | " + core.Serial);
+                Console.WriteLine("Resuse Count     | " + core.ReuseCount);
+            }
+
+            Console.WriteLine();
         }
 
         private static async Task DisplayRestOfUpcomingLaunches(OddityCore oddity)

--- a/Oddity/Models/Cores/CoreInfo.cs
+++ b/Oddity/Models/Cores/CoreInfo.cs
@@ -8,11 +8,16 @@ namespace Oddity.Models.Cores
 {
     public class CoreInfo : ModelBase, IIdentifiable
     {
+        [JsonProperty("id")]
         public string Id { get; set; }
+
+        [JsonProperty("serial")]
         public string Serial { get; set; }
+
+        [JsonProperty("block")]
         public uint? Block { get; set; }
 
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        [JsonProperty("status", DefaultValueHandling = DefaultValueHandling.Populate)]
         public CoreStatus Status { get; set; }
 
         [JsonProperty("reuse_count")]


### PR DESCRIPTION
Querying a core with a query like:

    oddity.CoresEndpoint.Query().WithFieldEqual(a => a.Serial, "B1051")

Would always fail. Fixed that.

The model for cores did not have a `JsonProperty` attribute on the `Serial` property, this is fine for deserialization because it's not caps sensitive. However this meant that the query sent out would be `{"Serial":"B1051"}` which is not valid because queries are caps sensitive.

I've only fixed this in the one model I had an issue with, but I suspect this is a problem for quite a few other models!