### PR TITLE
Fixed accessing landing pads failing for certain launches

### DIFF
--- a/Oddity/Models/Launches/LaunchCoreInfo.cs
+++ b/Oddity/Models/Launches/LaunchCoreInfo.cs
@@ -28,7 +28,7 @@ namespace Oddity.Models.Launches
             set
             {
                 _coreId = value;
-                Core = new Lazy<CoreInfo>(() => Context.CoresEndpoint.Get(_coreId).Execute());
+                Core = new Lazy<CoreInfo>(() => _coreId == null ? null : Context.CoresEndpoint.Get(_coreId).Execute());
             }
         }
 
@@ -39,7 +39,7 @@ namespace Oddity.Models.Launches
             set
             {
                 _landpadId = value;
-                Landpad = new Lazy<LandpadInfo>(() => Context.LandpadsEndpoint.Get(_landpadId).Execute());
+                Landpad = new Lazy<LandpadInfo>(() => _landpadId == null ? null : Context.LandpadsEndpoint.Get(_landpadId).Execute());
             }
         }
 


### PR DESCRIPTION
This snippet fails at the moment:

    var launch = await oddity.LaunchesEndpoint.Get("5ed981d91f30554030d45c2a").ExecuteAsync();
    var core = launch.Cores[0];
    var pad = core.Landpad.Value;
    if (pad != null)
        Console.WriteLine(pad.Name);

[Here's the API response](https://api.spacexdata.com/v4/launches/5ed981d91f30554030d45c2a) that it's handling. It looks like the API is returning a non-null core, with almost all null properties for some reason (presumably because we know it'll be a re-used Falcon 9, but we don't know anything more about it?).

Oddity doesn't like this, because when you later try to access the `Landpad.Value` you're essentially calling `Context.LandpadsEndpoint.Get(null)`.

In this PR I've added checks for this specific case. However, I'm not sure if this is the best approach - maybe the `SimpleBuilder` should instead be updated to handle a request with a `null` ID by returning `null` data - that seems like it will fix most of these problems in one go.